### PR TITLE
Run 'find' asynchronously

### DIFF
--- a/bin/rofind
+++ b/bin/rofind
@@ -3,7 +3,7 @@
 # Requires: dmenu, xdg-utils 
 # To be used as a custom rofi mode. Example: rofi -show :rofind -modi :rofind
 if [ -z "$@" ]; then
-	find -not -path '*/\.*' 2> /dev/null
+	coproc (find -not -path '*/\.*' 2> /dev/null)
 else
 	case "$(echo $@ | cut -d " " -f 1)" in
 		a)


### PR DESCRIPTION
Running `find` during rofi execution for the first time takes significant time to index all the files in home directory. This makes it so that rofi can show up immediately, without waiting for `find` to finish.

Credits to OP https://bbs.archlinux.org/viewtopic.php?id=229095